### PR TITLE
version M.0.3.5

### DIFF
--- a/+spm1d/+stats/+anova/LinearModel.m
+++ b/+spm1d/+stats/+anova/LinearModel.m
@@ -25,7 +25,8 @@ classdef LinearModel
    end
    methods
        function self = LinearModel(Y, X, varargin)
-            if isvector(Y)
+           Y         = spm1d.util.flatten(Y); 
+           if isvector(Y)
                 self.dim = 0;
             else
                 self.dim = 1;

--- a/+spm1d/+stats/regress.m
+++ b/+spm1d/+stats/regress.m
@@ -3,6 +3,7 @@ function [SPM] = regress(Y, x, varargin)
 % Copyright (C) 2016 Todd Pataky
 % $Id: regress.m 1 2016-01-04 16:07 todd $
 
+Y             = spm1d.util.flatten(Y);
 [J,~]         = size(Y);
 X             = ones(J, 2);
 X(:,1)        = x;

--- a/+spm1d/+stats/ttest.m
+++ b/+spm1d/+stats/ttest.m
@@ -3,6 +3,7 @@ function [SPM] = ttest(Y, varargin)
 % Copyright (C) 2016 Todd Pataky
 % $Id: ttest.m 1 2016-01-04 16:07 todd $
 
+Y             = spm1d.util.flatten(Y);
 [J,~]         = size(Y);
 X             = ones(J, 1);
 c             = 1;

--- a/+spm1d/+stats/ttest2.m
+++ b/+spm1d/+stats/ttest2.m
@@ -3,6 +3,7 @@ function [SPM] = ttest2(yA, yB, varargin)
 % Copyright (C) 2016 Todd Pataky
 % $Id: ttest2.m 1 2016-01-04 16:07 todd $
 
+[yA,yB]       = deal(spm1d.util.flatten(yA), spm1d.util.flatten(yB));
 [nA,nB]       = deal(size(yA,1), size(yB,1));
 Y             = [yA; yB];
 % specify design and contrast:

--- a/+spm1d/+stats/ttest_paired.m
+++ b/+spm1d/+stats/ttest_paired.m
@@ -3,5 +3,5 @@ function [SPM] = ttest_paired(yA, yB, varargin)
 % Copyright (C) 2016 Todd Pataky
 % $Id: ttest_paired.m 1 2016-01-04 16:07 todd $
 
-
+[yA,yB] = deal(spm1d.util.flatten(yA), spm1d.util.flatten(yB));
 SPM = spm1d.stats.ttest(yA-yB, varargin{:});

--- a/+spm1d/+util/flatten.m
+++ b/+spm1d/+util/flatten.m
@@ -1,0 +1,10 @@
+function [y] = flatten(y)
+%__________________________________________________________________________
+% Copyright (C) 2016 Todd Pataky
+% $Id: flatten.m 1 2016-01-22 10:22 todd $
+
+if isvector(y)
+    y = y(:);
+end
+
+

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,1 +1,1 @@
-spm1d version M.0.3.4 (2016.01.21)
+spm1d version M.0.3.5 (2016.01.22)


### PR DESCRIPTION
Fixed a bug which raised an error in 0D analysis on row vectors.  Now able to submit column or row vectors to all spm1d.stats routines.