### PR TITLE
version M.0.3.6

### DIFF
--- a/+spm1d/+stats/+spm/SPM.m
+++ b/+spm1d/+stats/+spm/SPM.m
@@ -108,6 +108,13 @@ classdef SPM < matlab.mixin.CustomDisplay
                     clusters{i} = clusters{i}.inference(self.STAT, self.df, self.fwhm, self.resels, two_tailed, withBonf, self.nNodes);
                     p(i) = clusters{i}.P;
                 end
+                %re-order clusters left-to-right:
+                x = zeros(1,n);
+                for i = 1:n
+                    x(i) = clusters{i}.xy(1);
+                end
+                [~,ind] = sort(x);
+                [clusters,p] = deal( clusters(ind), p(ind) );
             end
         end
         

--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,1 +1,1 @@
-spm1d version M.0.3.5 (2016.01.22)
+spm1d version M.0.3.6 (2016.01.22)


### PR DESCRIPTION
Re-ordered clusters from left-to-right.  Previously clusters were ordered:  left-to-right (above upper-threshold clusters then below negative-threshold clusters).